### PR TITLE
Make compatible with Numpy 1.8 API.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,35 @@
+# Makefile - prepared for ctips
+#
+# `make` - Build and compile the ctips executable and python extension.
+# `make clean` - Remove all compiled (non-source) files that are created.
+#
+# If you are interested in the commands being run by this makefile, you may add
+# "VERBOSE=1" to the end of any `make` command, i.e.:
+#
+# 		make VERBOSE=1
+#
+# This will display the exact commands being used for building, etc.
+#
+
 SRCDIR = src/
 LIBDIR = lib/
 
+# Set verbosity
+#
+Q = @
+O = > /dev/null
+ifdef VERBOSE
+	ifeq ("$(origin VERBOSE)", "command line")
+		Q =
+		O =
+	endif
+endif
+
+
 all:
-	python setup.py build_ext --inplace
+	@echo "Building ctips Python extension."
+	$(Q) python setup.py build_ext --inplace $(O)
 	@mv -f *.so $(LIBDIR)
 	@rm -rf build/
-	@echo "\nSuccessful compilation"
 clean:
 	@rm -rf $(LIBDIR)*.so

--- a/include/ind.h
+++ b/include/ind.h
@@ -1,7 +1,7 @@
 /* Definitions for indexing Numpy arrays:                                   */
 
 /* 1D double ndarray:                                                       */
-#define INDd(a,i) *((double *)(a->data + i*a->strides[0]))
+#define INDd(a,i) *((double *)(PyArray_DATA(a) + i * PyArray_STRIDE(a, 0)))
 /* 1D integer ndarray:                                                      */
-#define INDi(a,i) *((int *)(a->data + i*a->strides[0]))
+#define INDi(a,i) *((int *)(PyArray_DATA(a) + i * PyArray_STRIDE(a, 0)))
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ incdir = 'include' # Include folder with header files
 
 files = os.listdir(srcdir)
 # This will filter the results for just the c files:
-files = filter(lambda x:     re.search('.+[.]c$',     x), files)
-files = filter(lambda x: not re.search('[.#].+[.]c$', x), files)
+files = list(filter(lambda x:     re.search('.+[.]c$',     x), files))
+files = list(filter(lambda x: not re.search('[.#].+[.]c$', x), files))
 
 inc = [get_include(), incdir]
 eca = []  # ['-fopenmp']

--- a/src/ctips.c
+++ b/src/ctips.c
@@ -1,4 +1,6 @@
 #include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_8_API_VERSION
 #include <numpy/arrayobject.h>
 
 #include "ind.h"
@@ -72,7 +74,7 @@ static PyObject *iso(PyObject *self, PyObject *args){
   size[0] = niso[mol];
 
   /* Fill in isotope ID's for this molecule:                                */
-  iso = (PyArrayObject *) PyArray_SimpleNew(1, size, PyArray_INT);
+  iso = (PyArrayObject *) PyArray_SimpleNew(1, size, NPY_INT);
   for (i=0; i<niso[mol]; i++){
     INDi(iso, i) = isoID[cumiso[mol]+i];
   }
@@ -111,11 +113,11 @@ static PyObject *tips(PyObject *self, PyObject *args){
     return NULL;
 
   /* Get array size:                                                        */
-  ndata = molID->dimensions[0];
+  ndata = PyArray_DIM(molID, 0);
   size[0] = ndata;
 
   /* Returned array with the partition function:                            */
-  Qarray = (PyArrayObject *) PyArray_SimpleNew(1, size, PyArray_DOUBLE);
+  Qarray = (PyArrayObject *) PyArray_SimpleNew(1, size, NPY_DOUBLE);
 
   /* Calculate the partition function for each input value:                 */
   for (i=0; i<ndata; i++){

--- a/src/ctips.c
+++ b/src/ctips.c
@@ -178,9 +178,32 @@ static PyMethodDef ctips_methods[] = {
 };
 
 
-/* When Python imports a C module named 'X' it loads the module             */
+#if PY_MAJOR_VERSION >= 3
+
+/* Module definition for Python 3.                                          */
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "ctips",
+    ctips__doc__,
+    -1,
+    ctips_methods
+};
+
+/* When Python 3 imports a C module named 'X' it loads the module           */
+/* then looks for a method named "PyInit_"+X and calls it.                  */
+PyObject *PyInit_ctips (void) {
+  PyObject *module = PyModule_Create(&moduledef);
+  import_array();
+  return module;
+}
+
+#else // Python 2
+
+/* When Python 2 imports a C module named 'X' it loads the module           */
 /* then looks for a method named "init"+X and calls it.                     */
 void initctips(void){
   Py_InitModule3("ctips", ctips_methods, ctips__doc__);
   import_array();
 }
+
+#endif


### PR DESCRIPTION
- Removes compiler warning.
- Uses Numpy's 1.8 API, so it should work against future Numpy releases.
- Ensures the code works under both Python 2 and 3.
- Tested with all isotopes - output is identical to current master.
